### PR TITLE
configurable logging level

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -4,7 +4,7 @@ import os
 logger = logging.getLogger(__name__)
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: sdx-mock-receipt: %(message)s"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
 
 RECEIPT_USER = os.getenv("RECEIPT_USER", "")
 RECEIPT_PASS = os.getenv("RECEIPT_PASS", "")


### PR DESCRIPTION
**Changes**
Enables the logging level to be set by an environment variable

**How to test**
Should work the same by default
Set environment variable to a valid logging level

**Who can test**
Anyone but @elliott-jenkins
