### PR TITLE
Add python 3.8 to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 dist: xenial
 python:
+    - "3.8"
     - "3.7"
     - "3.6"
 sudo: required


### PR DESCRIPTION
Add python 3.8 to travis builds so we can have confidence in our system when we end up upgrading the version of python we use